### PR TITLE
komiser_installation script

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ This repo consists of installation of :-
 - Terramate,It is a tool that enhances Terraform by providing features like code generation, stack management, orchestration, change detection, and data sharing
 - Goldilocks,is a tool that can help you identify an exact point for resource requests and limits. It provides a dashboard that gives recommendations on how to set your resource requests.
 - AWS CLI, is an open source tool that enables you to interact with AWS services using commands in your command-line shell. The script installs the current latest version of AWS CLI but also asks the user if they want to install a specific version of AWS CLI.
+- Komiser is an open-source cloud-agnostic resource manager designed to analyze and manage cloud cost, usage, security, and governance all in one place
 
   <br>You can refer these blogs for getting started, <br/>
     https://blog.knoldus.com/introduction-to-terraform-1/ <br/>

--- a/komiser_installation.sh
+++ b/komiser_installation.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+sudo apt update
+
+echo "Downloading the Komiser binary..............................................."
+wget https://cli.komiser.io/latest/komiser_Linux_x86_64 -O komiser
+
+# Make the downloaded file executable
+chmod +x komiser
+
+echo "Moving the Komiser binary to a directory included in your PATH..............................................."
+sudo mv komiser /usr/local/bin/
+
+echo "Adding Komiser alias to .bashrc for easy access..............................................."
+echo 'alias komiser="/usr/local/bin/komiser"' >> ~/.bashrc
+
+# Apply changes to the current shell session
+source ~/.bashrc
+
+echo "chechking komiser version..............................................."
+komiser --version


### PR DESCRIPTION
 this is a bash script to simplify the installation process for Komiser, a tool that allows users to analyze and manage their cloud services across multiple platforms from a single platform.