### PR TITLE
Pack-cli script

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,12 @@ This repo consists of installation of :-
 - Terramate,It is a tool that enhances Terraform by providing features like code generation, stack management, orchestration, change detection, and data sharing
 - Goldilocks,is a tool that can help you identify an exact point for resource requests and limits. It provides a dashboard that gives recommendations on how to set your resource requests.
 - AWS CLI, is an open source tool that enables you to interact with AWS services using commands in your command-line shell. The script installs the current latest version of AWS CLI but also asks the user if they want to install a specific version of AWS CLI.
+- ### Installation Script for `pack-cli`
+      Use the provided script (`install_pack_cli.sh`) to easily install the Cloud Native Computing Foundation's `pack-cli` on your Debian-based system.
+ #### About `pack-cli`:
+`     pack-cli` is a Cloud Native Buildpacks command-line interface that simplifies the process of building container images from source code. It is designed to streamline the packaging and deployment of applications in a cloud- 
+      native environment.
+
 
   <br>You can refer these blogs for getting started, <br/>
     https://blog.knoldus.com/introduction-to-terraform-1/ <br/>

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ This repo consists of installation of :-
 - ##### Installation Script for `pack-cli`
         Use the provided script (`install_pack_cli.sh`) to easily install the Cloud Native Computing Foundation's `pack-cli` on your Debian-based system.
   ##### About `pack-cli`:
-`       pack-cli` is a Cloud Native Buildpacks command-line interface that simplifies the process of building container images from source code. It is designed to streamline the packaging and deployment of applications in a cloud- 
+        pack-cli is a Cloud Native Buildpacks command-line interface that simplifies the process of building container images from source code. It is designed to streamline the packaging and deployment of applications in a cloud- 
             native environment.
 
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ This repo consists of installation of :-
         Use the provided script (`install_pack_cli.sh`) to easily install the Cloud Native Computing Foundation's `pack-cli` on your Debian-based system.
   ##### About `pack-cli`:
 `       pack-cli` is a Cloud Native Buildpacks command-line interface that simplifies the process of building container images from source code. It is designed to streamline the packaging and deployment of applications in a cloud- 
-        native environment.
+            native environment.
 
 
   <br>You can refer these blogs for getting started, <br/>

--- a/README.md
+++ b/README.md
@@ -20,9 +20,7 @@ This repo consists of installation of :-
 - Terramate,It is a tool that enhances Terraform by providing features like code generation, stack management, orchestration, change detection, and data sharing
 - Goldilocks,is a tool that can help you identify an exact point for resource requests and limits. It provides a dashboard that gives recommendations on how to set your resource requests.
 - AWS CLI, is an open source tool that enables you to interact with AWS services using commands in your command-line shell. The script installs the current latest version of AWS CLI but also asks the user if they want to install a specific version of AWS CLI.
-- ##### Installation Script for `pack-cli`
-        Use the provided script (`install_pack_cli.sh`) to easily install the Cloud Native Computing Foundation's `pack-cli` on your Debian-based system.
-- About pack-cli: pack-cli is a Cloud Native Buildpacks command-line interface that simplifies the process of building container images from source code. It is designed to streamline the packaging and deployment of applications in 
+- About Pack-Cli: Pack-Cli is a Cloud Native Buildpacks command-line interface that simplifies the process of building container images from source code. It is designed to streamline the packaging and deployment of applications in 
   a cloud-native environment.
 
 

--- a/README.md
+++ b/README.md
@@ -22,9 +22,8 @@ This repo consists of installation of :-
 - AWS CLI, is an open source tool that enables you to interact with AWS services using commands in your command-line shell. The script installs the current latest version of AWS CLI but also asks the user if they want to install a specific version of AWS CLI.
 - ##### Installation Script for `pack-cli`
         Use the provided script (`install_pack_cli.sh`) to easily install the Cloud Native Computing Foundation's `pack-cli` on your Debian-based system.
-  ##### About `pack-cli`:
-        pack-cli is a Cloud Native Buildpacks command-line interface that simplifies the process of building container images from source code. It is designed to streamline the packaging and deployment of applications in a cloud- 
-            native environment.
+- About pack-cli: pack-cli is a Cloud Native Buildpacks command-line interface that simplifies the process of building container images from source code. It is designed to streamline the packaging and deployment of applications in 
+  a cloud-native environment.
 
 
   <br>You can refer these blogs for getting started, <br/>

--- a/README.md
+++ b/README.md
@@ -20,11 +20,11 @@ This repo consists of installation of :-
 - Terramate,It is a tool that enhances Terraform by providing features like code generation, stack management, orchestration, change detection, and data sharing
 - Goldilocks,is a tool that can help you identify an exact point for resource requests and limits. It provides a dashboard that gives recommendations on how to set your resource requests.
 - AWS CLI, is an open source tool that enables you to interact with AWS services using commands in your command-line shell. The script installs the current latest version of AWS CLI but also asks the user if they want to install a specific version of AWS CLI.
-- ### Installation Script for `pack-cli`
-      Use the provided script (`install_pack_cli.sh`) to easily install the Cloud Native Computing Foundation's `pack-cli` on your Debian-based system.
- #### About `pack-cli`:
-`     pack-cli` is a Cloud Native Buildpacks command-line interface that simplifies the process of building container images from source code. It is designed to streamline the packaging and deployment of applications in a cloud- 
-      native environment.
+- ##### Installation Script for `pack-cli`
+        Use the provided script (`install_pack_cli.sh`) to easily install the Cloud Native Computing Foundation's `pack-cli` on your Debian-based system.
+  ##### About `pack-cli`:
+`       pack-cli` is a Cloud Native Buildpacks command-line interface that simplifies the process of building container images from source code. It is designed to streamline the packaging and deployment of applications in a cloud- 
+        native environment.
 
 
   <br>You can refer these blogs for getting started, <br/>

--- a/pack-script.sh
+++ b/pack-script.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+# Function to check if a command is available
+command_exists() {
+    command -v "$1" >/dev/null 2>&1
+}
+
+# Check if pack-cli is already installed
+if command_exists pack; then
+    echo "pack-cli is already installed. Exiting."
+    exit 0
+fi
+
+# Add the repository
+echo "Adding the pack-cli repository..."
+sudo add-apt-repository ppa:cncf-buildpacks/pack-cli
+
+# Update package list
+echo "Updating package list..."
+sudo apt-get update
+
+# Install pack-cli
+echo "Installing pack-cli..."
+sudo apt-get install -y pack-cli
+
+# Check if installation was successful
+if command_exists pack; then
+    echo "pack-cli has been successfully installed."
+else
+    echo "Error: pack-cli installation failed. Please check for errors above."
+fi
+
+# End of the script
+exit 0


### PR DESCRIPTION
Pack-Cli is a Cloud Native Buildpacks command-line interface that simplifies the process of building container images from source code. It is designed to streamline the packaging and deployment of applications in a cloud-native environment.

