### PR TITLE
komiser installation script

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ This repo consists of installation of :-
 - AWS CLI, is an open source tool that enables you to interact with AWS services using commands in your command-line shell. The script installs the current latest version of AWS CLI but also asks the user if they want to install a specific version of AWS CLI.
 - About Pack-Cli: Pack-Cli is a Cloud Native Buildpacks command-line interface that simplifies the process of building container images from source code. It is designed to streamline the packaging and deployment of applications in 
   a cloud-native environment.
+- Komiser is an open-source project that empowers users to optimize and manage their cloud resources efficiently. It is compatible with various cloud providers and deployment methods.
 
 
   <br>You can refer these blogs for getting started, <br/>

--- a/komiser_installation.sh
+++ b/komiser_installation.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+sudo apt update
+
+echo "Downloading the Komiser binary..............................................."
+wget https://cli.komiser.io/latest/komiser_Linux_x86_64 -O komiser
+
+# Make the downloaded file executable
+chmod +x komiser
+
+echo "Moving the Komiser binary to a directory included in your PATH..............................................."
+sudo mv komiser /usr/local/bin/
+
+echo "Adding Komiser alias to .bashrc for easy access..............................................."
+echo 'alias komiser="/usr/local/bin/komiser"' >> ~/.bashrc
+
+# Apply changes to the current shell session
+source ~/.bashrc
+
+echo "chechking komiser version..............................................."
+komiser --version


### PR DESCRIPTION
this is a bash script to simplify the installation process for Komiser, a tool that allows users to analyze and manage their cloud services across multiple platforms from a single platform.

