### PR TITLE
opentofu installation script

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,8 @@ This repo consists of installation of :-
 - Helm is a package manager for Kubernetes that allows developers and operators to more easily package, configure, and deploy applications and services onto Kubernetes cluster
 - BotKube is an open-source monitoring tool designed to provide real-time notifications and alerts, allowing DevOps teams to receive and manage updates about their Kubernetes environments directly within their preferred chat 
   applications.
+- OpenTofu is an open-source infrastructure as code (IaC) tool designed to automate the provisioning, configuration, and management of infrastructure. It allows developers and operations teams to define their infrastructure in code, 
+  enabling version control, reproducibility, and collaboration. It is particularly known for its flexibility and ease of use, making it an attractive option for teams of all sizes.
   <br>You can refer these blogs for getting started, <br/>
     https://blog.knoldus.com/introduction-to-terraform-1/ <br/>
     https://blog.knoldus.com/spinning-up-terraform-configuration-2/ <br/>

--- a/opentofu_install.sh
+++ b/opentofu_install.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+
+# Function to print messages
+print_message() {
+    echo "=> $1"
+}
+
+# Function to install dependencies
+install_dependencies() {
+    print_message "Updating package lists..."
+    sudo apt-get update -y
+
+    print_message "Installing required packages..."
+    sudo apt-get install -y curl git
+}
+
+# Function to download and install OpenTofu
+install_opentofu() {
+    print_message "Downloading OpenTofu..."
+    curl -Lo opentofu.tar.gz https://github.com/opentofu/cli/releases/latest/download/opentofu-linux-amd64.tar.gz
+
+    print_message "Extracting OpenTofu..."
+    tar -xzf opentofu.tar.gz
+
+    print_message "Installing OpenTofu..."
+    sudo mv opentofu /usr/local/bin/opentofu
+
+    print_message "Cleaning up..."
+    rm opentofu.tar.gz
+}
+
+# Function to verify installation
+verify_installation() {
+    print_message "Verifying OpenTofu installation..."
+    if command -v opentofu > /dev/null 2>&1; then
+        print_message "OpenTofu installed successfully!"
+        opentofu version
+    else
+        print_message "OpenTofu installation failed."
+    fi
+}
+
+# Main script execution
+print_message "Starting OpenTofu installation script..."
+install_dependencies
+install_opentofu
+verify_installation
+print_message "OpenTofu installation script completed."
+


### PR DESCRIPTION
this is a bash script to install opentofu ,an open-source infrastructure as code tool designed to automate the provisioning, configuration, and management of infrastructure. 